### PR TITLE
#25 Delete files with their folders

### DIFF
--- a/UploadBehavior.php
+++ b/UploadBehavior.php
@@ -197,9 +197,8 @@ class UploadBehavior extends Behavior
      */
     public function beforeDelete()
     {
-        $attribute = $this->attribute;
-        if ($this->unlinkOnDelete && $attribute) {
-            $this->delete($attribute);
+        if ($this->unlinkOnDelete) {
+            $this->deleteFolder($this->path);
         }
     }
 
@@ -323,5 +322,18 @@ class UploadBehavior extends Behavior
     protected function afterUpload()
     {
         $this->owner->trigger(self::EVENT_AFTER_UPLOAD);
+    }
+
+    /**
+     * Deletes folder with uploaded files
+     *
+     * @param string path
+     */
+    public function deleteFolder($path)
+    {
+        $dir = Yii::getAlias($this->resolvePath($path));
+        if (is_dir($dir)) {
+            FileHelper::removeDirectory($dir);
+        }
     }
 }

--- a/UploadImageBehavior.php
+++ b/UploadImageBehavior.php
@@ -117,6 +117,18 @@ class UploadImageBehavior extends UploadBehavior
     }
 
     /**
+     * @inheritdoc
+     */
+    public function beforeDelete()
+    {
+        parent::beforeDelete();
+
+        if ($this->unlinkOnDelete && $this->thumbPath !== null) {
+            $this->deleteFolder($this->thumbPath);
+        }
+    }
+
+    /**
      * @throws \yii\base\InvalidParamException
      */
     protected function createThumbs()


### PR DESCRIPTION
For UploadBehavior: delete folder that contains uploaded files on model deleting.
For UploadImageBehavior: delete folder that contains original uploaded images and one that contains thumbs on model deleting.
Depends on 'unlinkOnDelete' property.


https://github.com/mongosoft/yii2-upload-behavior/issues/25