### PR TITLE
change private to protected

### DIFF
--- a/UploadBehavior.php
+++ b/UploadBehavior.php
@@ -87,7 +87,7 @@ class UploadBehavior extends Behavior
     /**
      * @var UploadedFile the uploaded file instance.
      */
-    private $_file;
+    protected $_file;
 
 
     /**


### PR DESCRIPTION
For the reason easy to expand. When users what to do some extension, they can easy to deal with the file object.

eg.  I what to store the file into into the database after upload.