### PR TITLE
fixes #44: remove yiisoft/yii2-imagine dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Example view file:
 
 ### Upload image and create thumbnails
 
+Thumbnails processing requires [yiisoft/yii2-imagine](https://github.com/yiisoft/yii2-imagine) to be installed.
+
 Attach the behavior in your model:
 
 ```php

--- a/UploadImageBehavior.php
+++ b/UploadImageBehavior.php
@@ -230,6 +230,8 @@ class UploadImageBehavior extends UploadBehavior
      */
     protected function generateImageThumb($config, $path, $thumbPath)
     {
+        if (!class_exists(\yii\imagine\Image::class)) throw new \Exception("Thumbnails processing requires yiisoft/yii2-imagine to be installed");
+
         $width = ArrayHelper::getValue($config, 'width');
         $height = ArrayHelper::getValue($config, 'height');
         $quality = ArrayHelper::getValue($config, 'quality', 100);

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,14 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "yiisoft/yii2": "~2.0.0",
-        "yiisoft/yii2-imagine": "~2.0.0"
+        "yiisoft/yii2": "~2.0.0"
     },
     "require-dev": {
       "phpunit/phpunit": "~4.0",
       "phpunit/dbunit": "~1.0"
+    },
+    "suggest": {
+        "yiisoft/yii2-imagine": "For automatic thumbnails processing with UploadImageBehavior"
     },
     "autoload": {
         "psr-4": {

--- a/tests/UploadImageBehaviorTest.php
+++ b/tests/UploadImageBehaviorTest.php
@@ -29,6 +29,8 @@ class UploadImageBehaviorTest extends DatabaseTestCase
 
     public function testCreateUser()
     {
+        if (!$this->isImagineInstalled()) $this->markTestSkipped('No yii2-imagine installed');
+
         $user = new User([
             'nickname' => 'Alex',
         ]);
@@ -41,8 +43,15 @@ class UploadImageBehaviorTest extends DatabaseTestCase
         $this->assertEquals(sha1_file($path), sha1_file(__DIR__ . '/data/test-image.jpg'));
     }
 
+    protected function isImagineInstalled()
+    {
+        return class_exists(\yii\imagine\Image::class);
+    }
+
     public function testResizeUser()
     {
+        if (!$this->isImagineInstalled()) $this->markTestSkipped('No yii2-imagine installed');
+
         $user = User::findOne(1);
         $user->setScenario('update');
 


### PR DESCRIPTION
This PR removes yiisoft/yii2-imagine direct dependency, moving it to "suggest" section of `composer.json`.

Tests are updated to skip thumbnail related tests if no yiisoft/yii2-imagine is installed.

UploadImageBehavior throws descriptive exception if it has to generate thumbnails while no yiisoft/yii2-imagine is installed.