### PR TITLE
Added deleteOriginalFile option. #56

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Behavior Options
 * generateNewName - Set true or anonymous function takes the old filename and returns a new name, default value is `true`
 * unlinkOnSave - If `true` current attribute file will be deleted, default value is `true`
 * unlinkOnDelete - If `true` current attribute file will be deleted after model deletion.
+* deleteSourceAfterThumbsGenerating - Only for UploadImageBehavior. If `true` original image file will be deleted after thumbs generating, default value is `false`.
 
 ### Attention!
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Behavior Options
 * generateNewName - Set true or anonymous function takes the old filename and returns a new name, default value is `true`
 * unlinkOnSave - If `true` current attribute file will be deleted, default value is `true`
 * unlinkOnDelete - If `true` current attribute file will be deleted after model deletion.
-* deleteSourceAfterThumbsGenerating - Only for UploadImageBehavior. If `true` original image file will be deleted after thumbs generating, default value is `false`.
+* deleteOriginalFile - Only for UploadImageBehavior. If `true` original image file will be deleted after thumbs generating, default value is `false`.
 
 ### Attention!
 

--- a/src/UploadImageBehavior.php
+++ b/src/UploadImageBehavior.php
@@ -64,7 +64,7 @@ class UploadImageBehavior extends UploadBehavior
      * Defaults to FALSE
      * @var boolean
      */
-    public $deleteSourceAfterThumbsGenerating = false;
+    public $deleteOriginalFile = false;
     /**
      * @var array the thumbnail profiles
      * - `width`
@@ -95,21 +95,23 @@ class UploadImageBehavior extends UploadBehavior
 
         parent::init();
 
-        if ($this->thumbPath === null) {
-            $this->thumbPath = $this->path;
-        }
-        if ($this->thumbUrl === null) {
-            $this->thumbUrl = $this->url;
-        }
+        if ($this->createThumbsOnSave || $this->createThumbsOnRequest) {
+            if ($this->thumbPath === null) {
+                $this->thumbPath = $this->path;
+            }
+            if ($this->thumbUrl === null) {
+                $this->thumbUrl = $this->url;
+            }
 
-        foreach ($this->thumbs as $config) {
-            $width = ArrayHelper::getValue($config, 'width');
-            $height = ArrayHelper::getValue($config, 'height');
-            if ($height < 1 && $width < 1) {
-                throw new InvalidConfigException(sprintf(
-                    'Length of either side of thumb cannot be 0 or negative, current size ' .
+            foreach ($this->thumbs as $config) {
+                $width = ArrayHelper::getValue($config, 'width');
+                $height = ArrayHelper::getValue($config, 'height');
+                if ($height < 1 && $width < 1) {
+                    throw new InvalidConfigException(sprintf(
+                        'Length of either side of thumb cannot be 0 or negative, current size ' .
                         'is %sx%s', $width, $height
-                ));
+                    ));
+                }
             }
         }
     }
@@ -149,7 +151,7 @@ class UploadImageBehavior extends UploadBehavior
             }
         }
         
-        if ($this->deleteSourceAfterThumbsGenerating) {
+        if ($this->deleteOriginalFile) {
             parent::delete($this->attribute);
         }
     }


### PR DESCRIPTION
Added option to allow deleting original file after generating image thumbs (only UploadImageBehavior).

Also turned on filling default parameters in UploadImageBehavior::init() function (there was no filling before in case when createThumbsOnSave is false).