### PR TITLE
fixed is_file(): Passing null to parameter

### DIFF
--- a/src/UploadBehavior.php
+++ b/src/UploadBehavior.php
@@ -282,7 +282,7 @@ class UploadBehavior extends Behavior
     protected function delete($attribute, $old = false)
     {
         $path = $this->getUploadPath($attribute, $old);
-        if (is_file($path)) {
+        if (is_string($path) && is_file($path)) {
             unlink($path);
         }
     }


### PR DESCRIPTION
is_file(): Passing null to parameter #1 ($filename) of type string is deprecated

#69 fixed this issue